### PR TITLE
Fix setCookie usage in login page

### DIFF
--- a/Layouts/login.eta
+++ b/Layouts/login.eta
@@ -30,7 +30,7 @@
     document.cookie = `${name}=; expires=Thu, 18 Dec 2013 12:00:00 UTC; path=/`
   }
 
-  setCookie("auth", "", )
+  setCookie("auth", "", 0)
 
   $('#loginForm').on('click', function() {
     $('#loginWarning').css('display', 'none')


### PR DESCRIPTION
## Summary
- fix typo in `setCookie` call in login page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684aabea1134832aae4185e4c183ebc6