### PR TITLE
Add delete confirmation popup

### DIFF
--- a/Controllers/Index/Views/Index.eta
+++ b/Controllers/Index/Views/Index.eta
@@ -45,6 +45,24 @@
 
 <div id="searchResults" class="mt-2 mb-4"></div>
 
+<div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteModalLabel">Confirm Deletion</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Are you sure you want to delete this article?
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" id="confirmDeleteButton">Delete</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script>
     var results
     function getResults(searchTerm) {
@@ -109,19 +127,29 @@
 
     getResults('')
 
+    var deleteModal = new bootstrap.Modal(document.getElementById('deleteModal'))
+    var deleteArticleId
+
     $('#searchResults').on('click', '.kbDelete', function(){
-        var id = $(this).data('id')
+        deleteArticleId = $(this).data('id')
+        deleteModal.show()
+    })
+
+    $('#confirmDeleteButton').on('click', function(){
+        if(!deleteArticleId)
+            return
         $.ajax({
             type: 'POST',
             url: `/Api/DeleteKnowledgeArticle`,
             data: {
-                id: id
+                id: deleteArticleId
             },
             success: (data) => {
                 if (data == "success")
                     getResults($('#kbaseSearch').val())
             }
         })
+        deleteModal.hide()
     })
 
     $.ajax({


### PR DESCRIPTION
## Summary
- confirm article deletion with a Bootstrap modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ab9de2878832a82b3754fcd617d5e