### PR TITLE
Enable editing of knowledge base articles

### DIFF
--- a/Controllers/Api/ApiController.js
+++ b/Controllers/Api/ApiController.js
@@ -35,6 +35,21 @@ module.exports = {
 
         return "success"
     },
+    EditKnowledgeArticle: (data) => {
+        if (!auth.authenticate(data.req).success)
+            return
+        data = Object.assign({}, data.req.body)
+        if (!data.id)
+            return "Article id missing."
+        if (data.title == '' || data.plainText == '')
+            return "Title or plaintext cannot be empty."
+
+        db.prepare(`UPDATE articles SET title = ?, html = ?, plainText = ?, tags = ? WHERE id = ?`).run(
+            data.title, data.html, data.plainText, data.tags ?? '', data.id
+        )
+
+        return "success"
+    },
     Search: (data) => {
         if (!auth.authenticate(data.req).success)
             return

--- a/Controllers/Edit/EditController.js
+++ b/Controllers/Edit/EditController.js
@@ -1,0 +1,25 @@
+const auth = require.main.require('./Utilities/Auth')
+const db = require.main.require('./Utilities/Database').db
+
+module.exports = {
+    Edit: async (data) => {
+        if (!auth.authenticate(data.req).success)
+            return await data.eta.renderFile('login.eta', {
+                root: data.root,
+                developer: data.serverData.environment == "dev",
+                views: `${data.root}/Layouts/`
+            })
+        const id = data.req.query.id
+        if(!id)
+            return 'Article id missing'
+        const article = db.prepare('SELECT * FROM articles WHERE id = ?').get(id)
+        if(!article)
+            return 'Article not found'
+        return await data.eta.renderFile(`/Views/edit.eta`, {
+            root: data.root,
+            developer: data.serverData.environment == "dev",
+            views: __dirname,
+            article: article
+        })
+    }
+}

--- a/Controllers/Edit/Views/edit.eta
+++ b/Controllers/Edit/Views/edit.eta
@@ -1,0 +1,72 @@
+<% layout(`../../Layouts/_Layout.eta`, {
+    title: "Edit Knowledge Base Article",
+}) %>
+<a class="d-inline btn btn-sm btn-secondary" href="/">Go Back</a>
+
+<h3 class="mt-3">Edit knowledge base article</h3>
+
+<form id="kbaseEditForm" method="post" class="mt-3" action="/Api/EditKnowledgeArticle" data-ajax="true" data-success="alert(`success`)">
+    <input id="articleId" type="hidden" value="<%= it.article.id %>" />
+    <label class="form-label">Title:</label>
+    <input id="kbaseTitle" type="text" class="form-control" name="title" value="<%= it.article.title %>" />
+    <br/>
+    <label class="form-label">Description:</label>
+    <div id="editor"></div>
+    <br />
+    <label class="form-label">Tags (separate by space):</label>
+    <input id="kbaseTags" type="text" class="form-control" value="<%= it.article.tags %>" />
+    <br />
+    <div id="formFail" class="alert alert-danger mt-2 text-center" style="display: none"></div>
+    <input type="submit" class="btn btn-primary" />
+</form>
+
+<script>
+    var quill = new Quill('#editor', {
+        modules: {
+            toolbar: [
+            ['bold', 'italic', 'underline', 'strike'],
+            ['blockquote', 'code-block'],
+            [{ 'header': 1 }, { 'header': 2 }],
+            [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+            [{ 'script': 'sub'}, { 'script': 'super' }],
+            [{ 'indent': '-1'}, { 'indent': '+1' }],
+            [{ 'direction': 'rtl' }],
+            [{ 'size': ['small', false, 'large', 'huge'] }],
+            [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+            [{ 'color': [] }, { 'background': [] }],
+            [{ 'font': [] }],
+            [{ 'align': [] }],
+            ['clean']
+          ]
+        },
+        theme: 'snow'
+    })
+    quill.root.innerHTML = `<%= it.article.html.replace(/`/g, '\`') %>`
+
+    $('#kbaseEditForm').submit(function(e) {
+        e.preventDefault()
+        $.ajax({
+            type: 'POST',
+            url: $(this).prop("action"),
+            data: {
+                id: $('#articleId').val(),
+                title: $('#kbaseTitle').val(),
+                html: quill.root.innerHTML,
+                plainText: quill.getText().replace(`\n`, ''),
+                tags: $('#kbaseTags').val()
+            },
+            success: (data) => {
+                if (data == "success")
+                    window.location = "/"
+                else {
+                    $('#formFail').html(data)
+                    $('#formFail').css('display', 'block')
+                }
+            }
+        })
+    })
+
+    $('#kbaseEditForm').on('click', function() {
+        $('#formFail').css('display', 'none')
+    })
+</script>

--- a/Controllers/Index/Views/Index.eta
+++ b/Controllers/Index/Views/Index.eta
@@ -99,6 +99,7 @@
             <h4>${r.title}</h4>
             <p class="d-inline-block"><span style="position:relative; top: 2px;">${new Date(r['date-created']).toLocaleString('en-GB', { timeZone: 'GMT' })}</span>
                 ${r.tags.length == 0 ? "" : r.tags.split(" ").map(x => `<button type="button" class="tag-button btn btn-outline-secondary btn-sm me-1 py-0 px-1">${x}</button>`).join("")}
+                <a href="/Edit?id=${r.id}" class="btn btn-outline-primary btn-sm d-inline-block py-0 me-1">Edit</a>
                 <button
                 type="button" class="kbDelete btn btn-outline-danger btn-sm d-inline-block py-0" data-id="${r.id}">Delete</button>
             </p>


### PR DESCRIPTION
## Summary
- add Edit controller and view
- allow articles to be updated through new API route
- show Edit option for each search result

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684adce5f1a0832ab130f2d27e49a1a3