### PR TITLE
Fix login cookie expiration

### DIFF
--- a/Layouts/login.eta
+++ b/Layouts/login.eta
@@ -47,7 +47,7 @@
       },
       success: (data) => {
         if (data.success) {
-          setCookie("auth", btoa(JSON.stringify({ id: data.id, key: data.key })))
+          setCookie("auth", btoa(JSON.stringify({ id: data.id, key: data.key })), 7)
           location.reload()
         } else {
           $('#loginWarning').html(data.msg.split('.').map(x => x.charAt(0).toUpperCase() + x.slice(1)).join(","))


### PR DESCRIPTION
## Summary
- set a one week expiry when storing auth cookie on successful login

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b4ab19f6c832a850d84aa1054b8a9